### PR TITLE
fix old imgmagick script link

### DIFF
--- a/linux
+++ b/linux
@@ -42,7 +42,7 @@ log_info "Installing Redis ..."
 
 log_info "Installing ImageMagick ..."
   sudo apt-get -y install libtool
-  wget https://raw.githubusercontent.com/discourse/discourse_docker/master/image/base/install-imagemagick
+  wget https://raw.githubusercontent.com/discourse/discourse_docker/main/image/base/install-imagemagick
   chmod +x install-imagemagick
   sudo ./install-imagemagick
 


### PR DESCRIPTION
The main and master branches exist at the same time in discourse_docker repo
The master branch is older (85 commits behind)