### PR TITLE
Updated node from 14 to 16 for Linux

### DIFF
--- a/linux
+++ b/linux
@@ -90,8 +90,8 @@ log_info "Installing MailHog ..."
   sudo wget -qO /usr/bin/mailhog https://github.com/mailhog/MailHog/releases/download/v1.0.1/MailHog_linux_amd64
   sudo chmod +x /usr/bin/mailhog
 
-log_info "Installing Node.js 14 ..."
-  curl -sL https://deb.nodesource.com/setup_14.x | sudo bash -
+log_info "Installing Node.js 16 ..."
+  curl -sL https://deb.nodesource.com/setup_16.x | sudo bash -
   sudo apt-get -y install nodejs
   sudo npm install -g svgo
   sudo npm install -g yarn


### PR DESCRIPTION
Prevents this error during the installation:

``` 
yarn install v1.22.19
[1/5] Validating package.json...
error discourse@1.0.0: The engine "node" is incompatible with this module. Expected version "16.* || >= 18". Got "14.20.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```