### PR TITLE
Reentrant script

### DIFF
--- a/mac
+++ b/mac
@@ -89,7 +89,7 @@ log_info "Installing coreutils ..."
 ruby_version="2.7.3"
 
 log_info "Installing Ruby $ruby_version ..."
-  rbenv install "$ruby_version"
+  rbenv install -s "$ruby_version"
 
 log_info "Setting $ruby_version as global default Ruby ..."
   rbenv global "$ruby_version"

--- a/mac
+++ b/mac
@@ -48,7 +48,7 @@ log_info "Installing Postgres, a good open source relational database ..."
   brew install postgresql@14
 
 log_info "Starting Postgres ..."
-  brew services start postgresql@14
+  brew services restart postgresql@14
 
 log_info "Installing Redis, a good key-value database ..."
   brew install redis

--- a/mac
+++ b/mac
@@ -54,7 +54,7 @@ log_info "Installing Redis, a good key-value database ..."
   brew install redis
 
 log_info "Starting Redis ..."
-  brew services start redis
+  brew services restart redis
 
 log_info "Installing and linking ImageMagick, to crop and resize images ..."
   brew install imagemagick


### PR DESCRIPTION
If you run the script once, it starts PostgreSQL so that the second time you run it the script fails. The solutions is to use `restart` rather than `start`. That way it will ensure the sever is started whether or not it's already running. (One possible downside is if you don't want PostgreSQL to go down because you've installed Discourse. In that case, you probably shouldn't be using this script.)

There's also a prompt to reinstall Ruby that means you _must_ reinstall or the scrip will just stop. Add the `-s` option skips installation if rbenv sees that version is already installed.

Finally, I changed from `start` to `restart` for the Redis server too. It doesn't fail if Redis is already running, but if you happen to update Redis, that update won't go into effect until you restart the server. 