### PR TITLE
FEATURE: Use latest Ruby 2.7 version on Mac

### DIFF
--- a/mac
+++ b/mac
@@ -86,7 +86,7 @@ log_info "Installing image libs ..."
 log_info "Installing coreutils ..."
   brew install coreutils
 
-ruby_version="2.7.3"
+ruby_version="2.7.6"
 
 log_info "Installing Ruby $ruby_version ..."
   rbenv install "$ruby_version"


### PR DESCRIPTION
### What's up?

In #30 we updated the Linux installer to use the latest Ruby 2.7 version. This PR extends that same change to the Mac installer.