### PR TITLE
FIX: Install latest tested version (13) of Postgres

### DIFF
--- a/mac
+++ b/mac
@@ -45,10 +45,10 @@ log_info "Installing Homebrew Services"
   brew tap homebrew/services
 
 log_info "Installing Postgres, a good open source relational database ..."
-  brew install postgresql@14
+  brew install postgresql@13
 
 log_info "Starting Postgres ..."
-  brew services start postgresql@14
+  brew services start postgresql@13
 
 log_info "Installing Redis, a good key-value database ..."
   brew install redis


### PR DESCRIPTION
There are some known test failures when running on Postgres@14.

Related to:

  https://akorotkov.github.io/blog/2021/05/22/pg-14-query-parsing/

Until we fix these we should install the known working version.