### PR TITLE
FIX: Set ruby_version from 2.7.6 to 3.1.3

### DIFF
--- a/linux
+++ b/linux
@@ -68,7 +68,7 @@ if [[ ! -d "$HOME/.rbenv/plugins/ruby-build" ]]; then
     git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
 fi
 
-ruby_version="2.7.6"
+ruby_version="3.1.3"
 
 log_info "Installing Ruby $ruby_version ..."
   rbenv install "$ruby_version"

--- a/mac
+++ b/mac
@@ -86,7 +86,7 @@ log_info "Installing image libs ..."
 log_info "Installing coreutils ..."
   brew install coreutils
 
-ruby_version="2.7.6"
+ruby_version="3.1.3"
 
 log_info "Installing Ruby $ruby_version ..."
   rbenv install "$ruby_version"


### PR DESCRIPTION
When calling `bundle install`, it prompts that Discourse requires Ruby >=3.1.3. It doesn't make sense that the shell script sets global Ruby version to 2.7.6.