### PR TITLE
DEV: Linux script updates

### DIFF
--- a/linux
+++ b/linux
@@ -34,6 +34,7 @@ log_info "Installing sqlite3 ..."
 
 log_info "Installing Postgres ..."
   sudo -E apt-get -y install postgresql postgresql-server-dev-all postgresql-contrib libpq-dev
+  cd /tmp && sudo -u postgres createuser -s "$USER"
 
 log_info "Installing curl ..."
   sudo -E apt-get -y install curl

--- a/linux
+++ b/linux
@@ -27,7 +27,7 @@ log_info "Installing build essentials ..."
   sudo -E apt-get -y install build-essential
 
 log_info "Installing libraries for common gem dependencies ..."
-  sudo -E apt-get -y install libxslt1-dev libcurl4-openssl-dev libksba8 libksba-dev libreadline-dev libssl-dev zlib1g-dev libsnappy-dev
+  sudo -E apt-get -y install libxslt1-dev libcurl4-openssl-dev libksba8 libksba-dev libreadline-dev libssl-dev zlib1g-dev libsnappy-dev libyaml-dev
 
 log_info "Installing sqlite3 ..."
  sudo -E apt-get -y install libsqlite3-dev sqlite3

--- a/linux
+++ b/linux
@@ -49,7 +49,7 @@ log_info "Installing Redis ..."
     rm redis-stable.tar.gz && \
     rm -Rf redis-stable
 
-  redis-server
+  redis-server --daemonize yes
 
 log_info "Installing ImageMagick ..."
   sudo -E apt-get -y install libtool
@@ -60,6 +60,15 @@ log_info "Installing ImageMagick ..."
 log_info "Installing image utilities ..."
   sudo -E apt-get -y install advancecomp gifsicle jpegoptim libjpeg-progs optipng pngcrush pngquant
   sudo -E apt-get -y install jhead
+
+  # Install oxipng
+  cd /tmp && \
+    wget https://github.com/shssoichiro/oxipng/releases/download/v8.0.0/oxipng-8.0.0-x86_64-unknown-linux-musl.tar.gz && \
+    tar -xzvf oxipng-8.0.0-x86_64-unknown-linux-musl.tar.gz && \
+    sudo cp oxipng-8.0.0-x86_64-unknown-linux-musl/oxipng /usr/local/bin
+  cd /tmp && \
+    rm oxipng-8.0.0-x86_64-unknown-linux-musl.tar.gz && \
+    rm -Rf oxipng-8.0.0-x86_64-unknown-linux-musl
 
 if [[ ! -d "$HOME/.rbenv" ]]; then
   log_info "Installing rbenv ..."
@@ -79,7 +88,7 @@ if [[ ! -d "$HOME/.rbenv/plugins/ruby-build" ]]; then
     git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
 fi
 
-ruby_version="3.1.3"
+ruby_version="3.2.1"
 
 log_info "Installing Ruby $ruby_version ..."
   rbenv install "$ruby_version"
@@ -101,8 +110,8 @@ log_info "Installing MailHog ..."
   sudo wget -qO /usr/bin/mailhog https://github.com/mailhog/MailHog/releases/download/v1.0.1/MailHog_linux_amd64
   sudo chmod +x /usr/bin/mailhog
 
-log_info "Installing Node.js 16 ..."
-  curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+log_info "Installing Node.js 18 ..."
+  curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash -
   sudo -E apt-get -y install nodejs
   sudo npm install -g svgo
   sudo npm install -g yarn

--- a/linux
+++ b/linux
@@ -39,10 +39,17 @@ log_info "Installing curl ..."
   sudo -E apt-get -y install curl
 
 log_info "Installing Redis ..."
-  curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
-  echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
-  sudo -E apt-get update
-  sudo -E apt-get -y install redis
+  cd /tmp && \
+    wget https://download.redis.io/redis-stable.tar.gz && \
+    tar -xzvf redis-stable.tar.gz && \
+    cd redis-stable && \
+    make && \
+    sudo -E make install
+  cd /tmp && \
+    rm redis-stable.tar.gz && \
+    rm -Rf redis-stable
+
+  redis-server
 
 log_info "Installing ImageMagick ..."
   sudo -E apt-get -y install libtool


### PR DESCRIPTION
- Install libyaml-dev (needed for ruby 3.2.x)
- Move create pg user to the "install Postgres step"
- Install oxipng
- Bump ruby version to 3.2.1
- Bump node version


Fix redis install. For some reason the apt source for redis isn't working on 22.10, so we
can just compile it directly.

```
E: Failed to fetch https://packages.redis.io/deb/dists/kinetic/InRelease  403  Forbidden
E: The repository 'https://packages.redis.io/deb kinetic InRelease' is not signed.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
failed
```
