### PR TITLE
FIX: The PostgreSQL service not starting after installation (WSL2 context)

### DIFF
--- a/linux
+++ b/linux
@@ -34,6 +34,7 @@ log_info "Installing sqlite3 ..."
 
 log_info "Installing Postgres ..."
   sudo -E apt-get -y install postgresql postgresql-server-dev-all postgresql-contrib libpq-dev
+  sudo -E service postgresql status || sudo -E service postgresql start
   cd /tmp && sudo -u postgres createuser -s "$USER"
 
 log_info "Installing curl ..."


### PR DESCRIPTION
In the WSL 2 context installation, for some reason, the service is not starting automatically after the `apt` installation.
It happens on a fresh Ubuntu 22 installation.

```
createuser: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory
        Is the server running locally and accepting connections on that socket?
failed
```

The proposed & tested solution is to check if the service is up; if not, we start it. 
`service postgresql status` returns a non-zero exit code if the service isn’t running.

![image](https://user-images.githubusercontent.com/360640/230179666-1472460e-8868-4696-bb88-cac101fe67bf.png)
