### PR TITLE
`linux` missing space, incorrect permission and unit file has no installation config

### DIFF
--- a/linux
+++ b/linux
@@ -51,8 +51,9 @@ log_info "Installing Redis ..."
     rm -Rf redis-stable
 
   sudo adduser --system --group --no-create-home redis
-  if [ ! -f "/etc/systemd/system/redis-server.service" ]; then
-    sudo cat > /etc/systemd/system/redis-server.service <<EOF
+  FILE="/etc/systemd/system/redis-server.service"
+  if [ ! -f "$FILE" ]; then
+    sudo bash -c "cat > $FILE" <<EOF
 [unit]
 description=redis in-memory data store
 after=network.target

--- a/linux
+++ b/linux
@@ -51,7 +51,7 @@ log_info "Installing Redis ..."
     rm -Rf redis-stable
 
   sudo adduser --system --group --no-create-home redis
-  if [ ! -f "/etc/systemd/system/redis-server.service"]; then
+  if [ ! -f "/etc/systemd/system/redis-server.service" ]; then
     sudo cat > /etc/systemd/system/redis-server.service <<EOF
 [unit]
 description=redis in-memory data store


### PR DESCRIPTION
I was following *[Discourse Meta Install Discourse on Ubuntu or Debian for Development](https://meta.discourse.org/t/install-discourse-on-ubuntu-or-debian-for-development/14727)* on a new Ubuntu Desktop 22.04.03 LTS and faced multiple issues, following [the latest commit](https://github.com/discourse/install-rails/commit/d23c672f5185ed5e43b9b26aa432940288be4925) of @oblakeerickson:

1. [At line 54](https://github.com/discourse/install-rails/blob/d23c672f5185ed5e43b9b26aa432940288be4925/linux#L54) I was getting:

```
/dev/fd/63: line 54: [: missing `]'
```

then:

```
Failed to enable unit: Unit file redis-server.service does not exist.
failed
```

follows.

2. [At line 55](https://github.com/discourse/install-rails/blob/d23c672f5185ed5e43b9b26aa432940288be4925/linux#L55C5-L69C4) I was getting:

```
linux: line 55: /etc/systemd/system/redis-server.service: Permission denied
failed
```

3. I'm now getting [at line 96](https://github.com/discourse/install-rails/blob/d23c672f5185ed5e43b9b26aa432940288be4925/linux#L96):

```
The unit files have no installation config (WantedBy=, RequiredBy=, Also=,
Alias= settings in the [Install] section, and DefaultInstance= for template
units). This means they are not meant to be enabled using systemctl.
 
Possible reasons for having this kind of units are:
• A unit may be statically enabled by being symlinked from another unit's
  .wants/ or .requires/ directory.
• A unit's purpose may be to act as a helper for some other unit which has
  a requirement dependency on it.
• A unit may be started when needed via activation (socket, path, timer,
  D-Bus, udev, scripted systemctl call, ...).
• In case of template units, the unit is meant to be enabled with some
  instance name specified.
```

[At line 97](https://github.com/discourse/install-rails/blob/d23c672f5185ed5e43b9b26aa432940288be4925/linux#L97):

```
Failed to start redis-server.service: Unit redis-server.service has a bad unit file setting.
See system logs and 'systemctl status redis-server.service' for details.
failed
```

but as I don't know for this one I let someone correct this issue.

As a temporary workaround using the penultimate `linux` works fine with:

```
bash <(wget -qO- https://raw.githubusercontent.com/discourse/install-rails/7df681f948372a1e31b292c70344243f9898688d/linux)
```