### PR TITLE
Update mac - upgrade openssl from v1.1 to v3

### DIFF
--- a/mac
+++ b/mac
@@ -84,8 +84,8 @@ log_info "Installing ruby-build, to install Rubies ..."
   brew install ruby-build
 
 log_info "Upgrading and linking OpenSSL ..."
-  brew install openssl@1.1
-  brew link openssl@1.1 --force
+  brew install openssl@3
+  brew link openssl@3 --force
 
 log_info "Installing image libs ..."
   brew install advancecomp jhead jpegoptim jpeg optipng oxipng pngcrush pngquant


### PR DESCRIPTION
Upgrading and linking OpenSSL ...

Error: openssl@1.1 has been disabled because it is not supported upstream! It was disabled on 2024-10-24. failed