### PR TITLE
DEV: Update the MacOS install script

### DIFF
--- a/mac
+++ b/mac
@@ -54,7 +54,10 @@ log_info "Starting Postgres ..."
   brew services start postgresql@13
 
 log_info "Adding Postgres to PATH ..."
-echo 'export PATH="/opt/homebrew/opt/postgresql@13/bin:$PATH"' >> ~/.zshrc
+echo 'export PATH="/opt/homebrew/opt/postgresql@13/bin:$PATH"' >> $shell_file
+echo 'export PATH="/opt/homebrew/opt/libpq/bin:$PATH"' >> $shell_file
+export PATH="/opt/homebrew/opt/postgresql@13/bin:$PATH"
+export PATH="/opt/homebrew/opt/libpq/bin:$PATH"
 
 log_info "Installing Redis, a good key-value database ..."
   brew install redis

--- a/mac
+++ b/mac
@@ -36,7 +36,6 @@ log_info() {
 if ! command -v brew &>/dev/null; then
   log_info "Installing Homebrew, a good OS X package manager ..."
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-  (echo; echo 'eval "$(/opt/homebrew/bin/brew shellenv)"') >> $shell_profile
   eval "$(/opt/homebrew/bin/brew shellenv)"
 else
   log_info "Homebrew already installed. Skipping ..."
@@ -49,7 +48,7 @@ log_info "Installing Homebrew Services"
   brew tap homebrew/services
 
 log_info "Installing Postgres, a good open source relational database ..."
-  brew install postgresql@13
+  brew install postgresql@13 libpq
 
 log_info "Starting Postgres ..."
   brew services start postgresql@13
@@ -69,23 +68,16 @@ log_info "Installing and linking ImageMagick, to crop and resize images ..."
 log_info "Installing rbenv, to change Ruby versions ..."
   brew install rbenv
 
-  if ! grep -qs "rbenv init" $shell_file; then
-    printf '\n# load rbenv\n' >> $shell_file
-    printf 'export PATH="$HOME/.rbenv/bin:$PATH"\n' >> $shell_file
-    printf 'eval "$(rbenv init - --no-rehash)"\n' >> $shell_file
-
-    log_info "Enable shims and autocompletion ..."
-      eval "$(rbenv init -)"
+  if ! command -v rbenv &>/dev/null; then
+    rbenv init
+    eval "$(rbenv init -)"
   fi
-
-  export PATH="$HOME/.rbenv/bin:$PATH"
 
 log_info "Installing ruby-build, to install Rubies ..."
   brew install ruby-build
 
-log_info "Upgrading and linking OpenSSL ..."
-  brew install openssl@1.1
-  brew link openssl@1.1 --force
+log_info "Upgrading OpenSSL ..."
+  brew install openssl
 
 log_info "Installing image libs ..."
   brew install advancecomp jhead jpegoptim jpeg optipng oxipng pngcrush pngquant


### PR DESCRIPTION
Here are a bunch of small updates to the MacOS install script:

- No need to manually add `brew` and `rbenv` config to rc/profile files, they do this automatically. Still keep running it in the current terminal, however, since that allows the script to run all at once.
- Add `libpq`, which is needed to build the `pg` gem.
- Move to the current `openssl` version, as `openssl@1.1` is [disabled](https://formulae.brew.sh/formula/openssl@1.1).
- No need to force linking `openssl`, it stopped being keg-only [some time ago](https://github.com/Homebrew/homebrew-core/commit/ea414a260c4c62dc907ddf43f72cb3c0ec0acd89).